### PR TITLE
chore: added co-location and message size limits

### DIFF
--- a/ansible/group_vars/node.yml
+++ b/ansible/group_vars/node.yml
@@ -30,6 +30,8 @@ nim_waku_rpc_tcp_port: 8545
 
 # Limits
 nim_waku_p2p_max_connections: 300
+nim_waku_ip_colocation_limit: 2
+nim_waku_max_msg_size: 'size:150KiB'
 
 # Store
 nim_waku_store_message_db_name: 'nim-waku'


### PR DESCRIPTION
*copy-pasta*

Hello!

With nwaku v0.24 new config parameters have been added.

--ip-colocation-limit=2 self-explanatory, limits connections from the same IP
--max-msg-size="150KiB" limits Waku messages to the specified size.

Don't merge before v0.24 is deployed 🙏

