### PR TITLE
waku.test: replace ws url with http for rln-relay

### DIFF
--- a/ansible/group_vars/node.yml
+++ b/ansible/group_vars/node.yml
@@ -59,7 +59,7 @@ nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain 
 # Waku rln-relay parameters
 nim_waku_rln_relay_dynamic: true
 nim_waku_rln_relay_eth_contract_address: '0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4'
-nim_waku_rln_relay_eth_client_address: 'ws://linux-01.ih-eu-mda1.nimbus.sepolia.wg:9557'
+nim_waku_rln_relay_eth_client_address: 'http://linux-01.ih-eu-mda1.nimbus.sepolia.wg:8556'
 nim_waku_rln_relay_tree_path: '/data/rln_relay_tree'
 
 # Consul Service


### PR DESCRIPTION
Since we have begun deprecation of ws/wss eth rpc urls, this PR replaces the ws endpoint usage in the waku.test fleet with a valid http rpc url. 
ref: https://github.com/waku-org/nwaku/pull/2442