### PR TITLE
ansible/group_vars/node.yml update contract and eth client addresses

### DIFF
--- a/ansible/group_vars/node.yml
+++ b/ansible/group_vars/node.yml
@@ -60,8 +60,8 @@ nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain 
 
 # Waku rln-relay parameters
 nim_waku_rln_relay_dynamic: true
-nim_waku_rln_relay_eth_contract_address: '0x4976Df0f61135EF3E5720D92eadE2e5F47A68Ef9'
-nim_waku_rln_relay_eth_client_address: 'https://rpc.cardona.zkevm-rpc.com'
+nim_waku_rln_relay_eth_contract_address: '0xCB33Aa5B38d79E3D9Fa8B10afF38AA201399a7e3'
+nim_waku_rln_relay_eth_client_address: 'http://linux-01.ih-eu-mda1.nimbus.sepolia.wg:8556'
 nim_waku_rln_relay_tree_path: '/data/rln_relay_tree'
 
 # Consul Service

--- a/ansible/group_vars/node.yml
+++ b/ansible/group_vars/node.yml
@@ -60,8 +60,8 @@ nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain 
 
 # Waku rln-relay parameters
 nim_waku_rln_relay_dynamic: true
-nim_waku_rln_relay_eth_contract_address: '0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4'
-nim_waku_rln_relay_eth_client_address: 'http://linux-01.ih-eu-mda1.nimbus.sepolia.wg:8556'
+nim_waku_rln_relay_eth_contract_address: '0x4976Df0f61135EF3E5720D92eadE2e5F47A68Ef9'
+nim_waku_rln_relay_eth_client_address: 'https://rpc.cardona.zkevm-rpc.com'
 nim_waku_rln_relay_tree_path: '/data/rln_relay_tree'
 
 # Consul Service


### PR DESCRIPTION
### Description

In `nwaku` `v0.30.0` we are using a completely new RLN approach, i.e., RLN_V2, which brings more flexibility regarding the established rate limit. With RLN_v2, the rate limit can be set to `N` messages per epoch, instead of 1 message per epoch.

In this PR we are updating `TWN` nodes to use the new smart contract address and a new rpc endpoint.

@rymnc , @alrevuelta - feel free to add anything I may have missed.

Infra - before applying these changes to the fleets we would need to coordinate and make sure we deploy the `v0.30.0` as well.