### PR TITLE
node: max-relay-peers to 200

### DIFF
--- a/ansible/group_vars/node.yml
+++ b/ansible/group_vars/node.yml
@@ -33,6 +33,8 @@ nim_waku_rpc_tcp_port: 8545
 
 # Limits
 nim_waku_p2p_max_connections: 300
+# Lower limit than max conns to allow space for other protocol and Waku canary.
+nim_waku_max_relay_peers: '{{ nim_waku_p2p_max_connections - 100 }}'
 
 # Store
 nim_waku_store_message_db_name: 'nim-waku'

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -22,7 +22,7 @@
 
 - name: infra-role-nim-waku
   src: git@github.com:status-im/infra-role-nim-waku.git
-  version: 3183cb517fce8767cc4aff27bf0a9275bb0907b9
+  version: d11ffbb1b4ba974446dc998658ed664586713139
 
 - name: infra-role-postgres-ha
   src: git@github.com:status-im/infra-role-postgres-ha.git


### PR DESCRIPTION
## Description
Given that we configure 300 as the max num of allowed p2p connections, after configuring the max num allowed relay connections we will have 100 connections for other protocols such as store, lightpush, etc.

## Related issue
- https://github.com/waku-org/nwaku/issues/3021