### PR TITLE
update requirements to avoid using rest-private parameter

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -22,7 +22,7 @@
 
 - name: infra-role-nim-waku
   src: git@github.com:status-im/infra-role-nim-waku.git
-  version: d11ffbb1b4ba974446dc998658ed664586713139
+  version: 600d9117039b43baebbc4374617050deb04db4ff
 
 - name: infra-role-postgres-ha
   src: git@github.com:status-im/infra-role-postgres-ha.git


### PR DESCRIPTION
This is needed because from `v0.33.0` we don't support the `rest-private` parameter.

- https://github.com/waku-org/nwaku/pull/3004
- https://github.com/status-im/infra-role-nim-waku/pull/33

Similar PR:
- https://github.com/status-im/infra-status/pull/45
